### PR TITLE
Fix incorrect error message for bad NIF when creating institution

### DIFF
--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/humanaethica/institution/InstitutionService.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/humanaethica/institution/InstitutionService.java
@@ -117,7 +117,7 @@ public class InstitutionService {
         try {
             Integer.parseInt(institutionDto.getNif());
         } catch (NumberFormatException nfe) {
-            throw new HEException(INVALID_NIF, institutionDto.getEmail());
+            throw new HEException(INVALID_NIF, institutionDto.getNif());
         }
 
         if (institutionRepository.findInstitutionByNif(institutionDto.getNif()).isPresent()) {


### PR DESCRIPTION
Corrects an incorrect error message when creating an institution. If the institution NIF fails to parse as an integer, the error message displays the email instead of the invalid NIF.
